### PR TITLE
fix(fridge-recipe): bug fixes and UX improvements from code review

### DIFF
--- a/apps/fridge-recipe/src/app/page.tsx
+++ b/apps/fridge-recipe/src/app/page.tsx
@@ -25,6 +25,12 @@ export default function Step1Page() {
     if (profile) setProfileAllergies(profile.allergies);
   }, []);
 
+  useEffect(() => {
+    return () => {
+      if (imageUrl) URL.revokeObjectURL(imageUrl);
+    };
+  }, [imageUrl]);
+
   function handleFile(file: File) {
     setImageFile(file);
     setImageUrl(URL.createObjectURL(file));
@@ -89,6 +95,8 @@ export default function Step1Page() {
           <div className="mb-5">
             <button
               onClick={() => setImageOpen((v) => !v)}
+              aria-expanded={imageOpen}
+              aria-controls="image-preview"
               className="mb-2 flex w-full items-center justify-between transition-opacity hover:opacity-70"
             >
               <span className="font-mono text-xs tracking-widest uppercase" style={{ color: "var(--muted)" }}>
@@ -102,7 +110,7 @@ export default function Step1Page() {
                 <polyline points="2,4 6,8 10,4" />
               </svg>
             </button>
-            {imageOpen && <ImageDropzone imageUrl={imageUrl} onFile={handleFile} />}
+            {imageOpen && <div id="image-preview"><ImageDropzone imageUrl={imageUrl} onFile={handleFile} /></div>}
           </div>
         ) : (
           <div className="mb-5">
@@ -136,10 +144,35 @@ export default function Step1Page() {
         {/* Error */}
         {status === "error" && errorMessage && (
           <div
-            className="mb-6 rounded-sm border px-4 py-3 font-mono text-xs"
+            className="mb-6 rounded-sm border px-4 py-3 font-mono text-xs space-y-2"
             style={{ borderColor: "var(--danger-mid)", background: "var(--danger-light)", color: "var(--danger)" }}
+            role="alert"
           >
-            {errorMessage}
+            <p>{errorMessage}</p>
+            <button
+              onClick={analyze}
+              disabled={!imageFile}
+              className="mt-1 underline underline-offset-2 hover:opacity-70 transition-opacity disabled:opacity-30"
+            >
+              다시 시도
+            </button>
+          </div>
+        )}
+
+        {/* Ingredient results — empty result */}
+        {status === "done" && ingredients.length === 0 && (
+          <div
+            className="mb-6 rounded-sm px-5 py-6 text-center"
+            style={{ background: "var(--surface)", border: "1px solid var(--border)" }}
+          >
+            <p className="text-sm font-medium mb-1" style={{ color: "var(--text)" }}>
+              재료를 찾지 못했어요
+            </p>
+            <p className="font-mono text-xs leading-relaxed mb-4" style={{ color: "var(--muted)" }}>
+              냉장고가 잘 보이는 사진으로 다시 시도하거나,<br />
+              아래에서 직접 재료를 추가해 보세요.
+            </p>
+            <IngredientTagList ingredients={ingredients} onChange={setIngredients} allergies={profileAllergies} />
           </div>
         )}
 
@@ -168,8 +201,14 @@ export default function Step1Page() {
         )}
 
         {/* Next step */}
+        {ingredients.length === 0 && status === "idle" && imageFile && (
+          <p className="mb-2 text-center font-mono text-xs" style={{ color: "var(--muted)" }}>
+            재료를 인식하거나 직접 추가한 후 레시피를 추천받을 수 있어요
+          </p>
+        )}
         <button
           disabled={ingredients.length === 0}
+          aria-disabled={ingredients.length === 0}
           onClick={() => {
             const params = ingredients.map(encodeURIComponent).join(",");
             router.push(`/step2?ingredients=${params}`);

--- a/apps/fridge-recipe/src/app/profile/page.tsx
+++ b/apps/fridge-recipe/src/app/profile/page.tsx
@@ -74,6 +74,9 @@ export default function ProfilePage() {
           <h1 className="font-display text-4xl font-light leading-tight" style={{ color: "var(--text)" }}>
             {isEdit ? "프로필 수정" : "프로필 설정"}
           </h1>
+          <p className="mt-2 font-mono text-xs leading-relaxed" style={{ color: "var(--muted)" }}>
+            여기서 설정한 식단, 알레르기, 특이사항은 레시피 추천 시 자동으로 반영됩니다.
+          </p>
         </header>
 
         <div className="space-y-6">
@@ -208,13 +211,19 @@ export default function ProfilePage() {
           )}
 
           {/* Save button */}
+          {!nickname.trim() && (
+            <p className="text-center font-mono text-xs" style={{ color: "var(--muted)" }}>
+              닉네임을 입력해야 저장할 수 있어요
+            </p>
+          )}
           <button
             onClick={handleSave}
             disabled={!nickname.trim() || saved}
+            aria-disabled={!nickname.trim() || saved}
             className="w-full rounded-sm py-3.5 text-sm font-medium tracking-wide transition-all duration-200 disabled:opacity-40"
             style={{ background: saved ? "var(--accent-mid)" : "var(--accent)", color: "var(--surface)", letterSpacing: "0.05em" }}
           >
-            {saved ? "저장됨" : "저장"}
+            {saved ? "저장 완료" : "저장"}
           </button>
         </div>
       </div>

--- a/apps/fridge-recipe/src/app/saved/page.tsx
+++ b/apps/fridge-recipe/src/app/saved/page.tsx
@@ -10,6 +10,7 @@ export default function SavedPage() {
   const [recipes, setRecipes] = useState<SavedRecipe[]>([]);
   const [allergies, setAllergies] = useState<string[]>([]);
   const [favoritesOnly, setFavoritesOnly] = useState(false);
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
 
   useEffect(() => {
     setRecipes(getSavedRecipes());
@@ -18,8 +19,14 @@ export default function SavedPage() {
   }, []);
 
   function handleDelete(id: string) {
-    deleteSavedRecipe(id);
-    setRecipes((prev) => prev.filter((r) => r.id !== id));
+    setPendingDeleteId(id);
+  }
+
+  function confirmDelete() {
+    if (!pendingDeleteId) return;
+    deleteSavedRecipe(pendingDeleteId);
+    setRecipes((prev) => prev.filter((r) => r.id !== pendingDeleteId));
+    setPendingDeleteId(null);
   }
 
   function handleFavorite(id: string) {
@@ -27,8 +34,54 @@ export default function SavedPage() {
     setRecipes((prev) => prev.map((r) => r.id === id ? { ...r, favorited: !r.favorited } : r));
   }
 
+  const filteredRecipes = favoritesOnly ? recipes.filter((r) => r.favorited) : recipes;
+
+  const pendingRecipeName = pendingDeleteId ? recipes.find((r) => r.id === pendingDeleteId)?.name : null;
+
   return (
     <main className="min-h-screen pb-20" style={{ background: "var(--bg)" }}>
+      {/* Delete confirmation dialog */}
+      {pendingDeleteId && (
+        <div
+          className="fixed inset-0 z-50 flex items-end justify-center pb-6 px-6"
+          style={{ background: "rgba(0,0,0,0.4)" }}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="delete-dialog-title"
+        >
+          <div
+            className="w-full max-w-[520px] rounded-sm p-5 space-y-4"
+            style={{ background: "var(--surface)", border: "1px solid var(--border)" }}
+          >
+            <div>
+              <p id="delete-dialog-title" className="text-sm font-medium" style={{ color: "var(--text)" }}>
+                레시피를 삭제하시겠어요?
+              </p>
+              {pendingRecipeName && (
+                <p className="mt-1 font-mono text-xs" style={{ color: "var(--muted)" }}>
+                  &ldquo;{pendingRecipeName}&rdquo;이(가) 영구적으로 삭제됩니다.
+                </p>
+              )}
+            </div>
+            <div className="flex gap-2">
+              <button
+                onClick={() => setPendingDeleteId(null)}
+                className="flex-1 rounded-sm py-2.5 text-sm font-medium transition-opacity hover:opacity-70"
+                style={{ border: "1px solid var(--border)", color: "var(--text)", background: "transparent" }}
+              >
+                취소
+              </button>
+              <button
+                onClick={confirmDelete}
+                className="flex-1 rounded-sm py-2.5 text-sm font-medium transition-opacity hover:opacity-80"
+                style={{ background: "var(--danger)", color: "white", border: "none" }}
+              >
+                삭제
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
       <div className="mx-auto max-w-[520px] px-6 py-12">
         <header className="mb-6">
           <div className="mb-3 flex items-center gap-3">
@@ -100,20 +153,27 @@ export default function SavedPage() {
               냉장고 사진 찍으러 가기
             </button>
           </div>
-        ) : (() => {
-          const filtered = favoritesOnly ? recipes.filter((r) => r.favorited) : recipes;
-          return filtered.length === 0 ? (
-            <div className="py-16 text-center">
-              <p className="text-sm" style={{ color: "var(--muted)" }}>즐겨찾기한 레시피가 없습니다</p>
-            </div>
-          ) : (
-            <div className="space-y-4">
-              {filtered.map((recipe, i) => (
-                <SavedRecipeCard key={recipe.id} recipe={recipe} onDelete={handleDelete} onFavorite={handleFavorite} allergies={allergies} index={recipes.length - recipes.indexOf(recipe)} />
-              ))}
-            </div>
-          );
-        })()}
+        ) : filteredRecipes.length === 0 ? (
+          <div className="py-16 text-center space-y-3">
+            <p className="text-sm font-medium" style={{ color: "var(--text)" }}>즐겨찾기한 레시피가 없어요</p>
+            <p className="font-mono text-xs" style={{ color: "var(--muted)" }}>
+              레시피 카드의 별 아이콘을 눌러 즐겨찾기에 추가해 보세요.
+            </p>
+            <button
+              onClick={() => setFavoritesOnly(false)}
+              className="mt-2 font-mono text-xs underline underline-offset-2 transition-opacity hover:opacity-60"
+              style={{ color: "var(--accent)" }}
+            >
+              전체 레시피 보기
+            </button>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {filteredRecipes.map((recipe) => (
+              <SavedRecipeCard key={recipe.id} recipe={recipe} onDelete={handleDelete} onFavorite={handleFavorite} allergies={allergies} index={recipes.length - recipes.indexOf(recipe)} />
+            ))}
+          </div>
+        )}
       </div>
     </main>
   );

--- a/apps/fridge-recipe/src/app/step2/page.tsx
+++ b/apps/fridge-recipe/src/app/step2/page.tsx
@@ -90,18 +90,22 @@ export default function Step2Page() {
   }, [streamingRecipes.length]);
 
   useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
     if (status === "streaming") {
       autoScrollRef.current = true;
       setShowScrollBtn(false);
-      setTimeout(() => {
+      timer = setTimeout(() => {
         window.scrollTo({ top: document.body.scrollHeight, behavior: "smooth" });
       }, 50);
     }
     if (status === "done") {
-      setTimeout(() => {
+      timer = setTimeout(() => {
         window.scrollTo({ top: document.body.scrollHeight, behavior: "smooth" });
       }, 100);
     }
+    return () => {
+      if (timer) clearTimeout(timer);
+    };
   }, [status]);
 
   const effectiveIngredients = excludeAllergies && allergies.length > 0
@@ -129,7 +133,7 @@ export default function Step2Page() {
       setErrorMessage(e instanceof Error ? e.message : "알 수 없는 오류");
       setStatus("error");
     }
-  }, [effectiveIngredients, conditions, allergies, excludeAllergies, specialNote]);
+  }, [effectiveIngredients, conditions, allergies, excludeAllergies, specialNote, sessionKey]);
 
   function handleSave(recipe: Recipe) {
     addSavedRecipe(recipe);
@@ -205,6 +209,16 @@ export default function Step2Page() {
               />
             ))}
           </div>
+          {(allergies.length > 0 || specialNote) && (
+            <div className="mt-3 pt-3 font-mono text-xs space-y-0.5" style={{ borderTop: "1px solid var(--border)", color: "var(--muted)" }}>
+              {allergies.length > 0 && (
+                <p>프로필 알레르기 반영 중: {allergies.join(", ")}</p>
+              )}
+              {specialNote && (
+                <p>특이사항 반영 중: {specialNote.length > 40 ? specialNote.slice(0, 40) + "…" : specialNote}</p>
+              )}
+            </div>
+          )}
         </div>
 
         {/* Condition selector */}
@@ -214,6 +228,8 @@ export default function Step2Page() {
         >
           <button
             onClick={() => setConditionsOpen((v) => !v)}
+            aria-expanded={conditionsOpen}
+            aria-controls="conditions-panel"
             className="flex w-full items-center justify-between px-5 py-4 transition-opacity hover:opacity-70"
           >
             <p className="font-display text-lg font-medium" style={{ color: "var(--text)" }}>
@@ -228,7 +244,7 @@ export default function Step2Page() {
             </svg>
           </button>
           {conditionsOpen && (
-            <div className="px-5 pb-5">
+            <div id="conditions-panel" className="px-5 pb-5">
               <ConditionSelector
                 value={conditions}
                 onChange={setConditions}
@@ -280,20 +296,34 @@ export default function Step2Page() {
         {/* Error */}
         {status === "error" && errorMessage && (
           <div
-            className="mb-6 rounded-sm border px-4 py-3 font-mono text-xs"
+            className="mb-6 rounded-sm border px-4 py-3 font-mono text-xs space-y-2"
             style={{ borderColor: "var(--danger-mid)", background: "var(--danger-light)", color: "var(--danger)" }}
+            role="alert"
           >
-            {errorMessage}
+            <p>{errorMessage}</p>
+            <button
+              onClick={request}
+              className="underline underline-offset-2 hover:opacity-70 transition-opacity"
+            >
+              다시 시도
+            </button>
           </div>
+        )}
+
+        {/* Streaming progress hint */}
+        {status === "streaming" && (
+          <p className="mb-3 font-mono text-xs text-center" style={{ color: "var(--muted)" }}>
+            AI가 레시피를 작성하고 있어요. 완성되는 순서대로 표시됩니다.
+          </p>
         )}
 
         {/* Progressive recipe cards */}
         {(streamingRecipes.length > 0 || skeletonCount > 0 || recipes.length > 0) && (
           <div className="space-y-4">
             {/* 완성된 카드 */}
-            {(status === "streaming" ? streamingRecipes : recipes).map((recipe, i) => (
+            {(status === "streaming" ? streamingRecipes : recipes).map((recipe) => (
               <RecipeCard
-                key={recipe.name + i}
+                key={recipe.name}
                 recipe={recipe}
                 saved={savedIds.has(recipe.name)}
                 onSave={handleSave}

--- a/apps/fridge-recipe/src/components/ConditionSelector.tsx
+++ b/apps/fridge-recipe/src/components/ConditionSelector.tsx
@@ -111,6 +111,7 @@ export default function ConditionSelector({ value, onChange, allergies = [], exc
               className="relative h-6 w-11 shrink-0 rounded-full transition-all duration-200"
               style={{ background: excludeAllergies ? "var(--accent)" : "var(--border)" }}
               aria-checked={excludeAllergies}
+              aria-label="알레르기 재료 제외"
               role="switch"
             >
               <span

--- a/apps/fridge-recipe/src/components/ImageDropzone.tsx
+++ b/apps/fridge-recipe/src/components/ImageDropzone.tsx
@@ -31,7 +31,11 @@ export default function ImageDropzone({ imageUrl, onFile }: Props) {
   return (
     <div className="space-y-2">
       <div
+        role="button"
+        tabIndex={0}
+        aria-label={imageUrl ? "다른 사진 선택" : "냉장고 사진 업로드"}
         onClick={() => inputRef.current?.click()}
+        onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); inputRef.current?.click(); } }}
         onDragOver={(e) => { e.preventDefault(); setDragging(true); }}
         onDragLeave={() => setDragging(false)}
         onDrop={(e) => {
@@ -40,14 +44,15 @@ export default function ImageDropzone({ imageUrl, onFile }: Props) {
           const file = e.dataTransfer.files[0];
           if (file) handle(file);
         }}
-        className="relative cursor-pointer overflow-hidden rounded-xl transition-all duration-300"
+        className="relative cursor-pointer overflow-hidden rounded-xl transition-all duration-300 focus:outline-none focus-visible:ring-2"
         style={{
           height: imageUrl ? 280 : 220,
           background: dragging ? "var(--accent-light)" : "var(--surface)",
           border: dragging
             ? "1.5px dashed var(--accent-mid)"
             : "1.5px dashed var(--border)",
-        }}
+          "--tw-ring-color": "var(--accent-mid)",
+        } as React.CSSProperties}
       >
         {imageUrl ? (
           <>
@@ -112,7 +117,7 @@ export default function ImageDropzone({ imageUrl, onFile }: Props) {
       </div>
 
       {fileError && (
-        <p className="font-mono text-xs" style={{ color: "var(--danger)" }}>
+        <p className="font-mono text-xs" role="alert" style={{ color: "var(--danger)" }}>
           {fileError}
         </p>
       )}

--- a/apps/fridge-recipe/src/components/IngredientTagList.tsx
+++ b/apps/fridge-recipe/src/components/IngredientTagList.tsx
@@ -19,7 +19,7 @@ export default function IngredientTagList({ ingredients, onChange, allergies = [
   }
 
   function onKeyDown(e: KeyboardEvent<HTMLInputElement>) {
-    if (e.key === "Enter") { e.preventDefault(); addIngredient(); }
+    if (e.key === "Enter" && !e.nativeEvent.isComposing) { e.preventDefault(); addIngredient(); }
   }
 
   return (

--- a/apps/fridge-recipe/src/components/Nav.tsx
+++ b/apps/fridge-recipe/src/components/Nav.tsx
@@ -49,7 +49,10 @@ export default function Nav() {
       }}
     >
       {LINKS.map(({ href, label, icon }) => {
-        const active = pathname === href || (href !== "/" && pathname.startsWith(href));
+        const active =
+          pathname === href ||
+          (href === "/" && pathname.startsWith("/step2")) ||
+          (href !== "/" && pathname.startsWith(href));
         return (
           <Link
             key={href}

--- a/apps/fridge-recipe/src/components/RecipeCard.tsx
+++ b/apps/fridge-recipe/src/components/RecipeCard.tsx
@@ -146,13 +146,19 @@ export default function RecipeCard({ recipe, onSave, saved, allergies = [] }: Pr
         <button
           onClick={() => onSave(recipe)}
           disabled={saved}
-          className="w-full rounded-sm py-2.5 text-sm font-medium transition-all duration-200 disabled:opacity-50"
+          aria-label={saved ? `${recipe.name} 저장 완료` : `${recipe.name} 저장`}
+          className="flex w-full items-center justify-center gap-2 rounded-sm py-2.5 text-sm font-medium transition-all duration-200 disabled:opacity-50"
           style={{
             background: saved ? "var(--accent-light)" : "transparent",
             color: saved ? "var(--accent-mid)" : "var(--accent)",
             border: `1.5px solid ${saved ? "transparent" : "var(--accent)"}`,
           }}
         >
+          {saved && (
+            <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <polyline points="2,7 5,10 11,3" />
+            </svg>
+          )}
           {saved ? "저장됨" : "저장"}
         </button>
       </div>

--- a/apps/fridge-recipe/src/lib/compressImage.ts
+++ b/apps/fridge-recipe/src/lib/compressImage.ts
@@ -17,7 +17,12 @@ export function compressImage(file: File): Promise<string> {
       const canvas = document.createElement("canvas");
       canvas.width = cw;
       canvas.height = ch;
-      canvas.getContext("2d")!.drawImage(img, 0, 0, cw, ch);
+      const ctx = canvas.getContext("2d");
+      if (!ctx) {
+        reject(new Error("Canvas 2D 컨텍스트를 가져올 수 없습니다."));
+        return;
+      }
+      ctx.drawImage(img, 0, 0, cw, ch);
 
       resolve(canvas.toDataURL("image/jpeg", QUALITY));
     };

--- a/apps/fridge-recipe/src/lib/openrouter.ts
+++ b/apps/fridge-recipe/src/lib/openrouter.ts
@@ -37,7 +37,7 @@ export async function recognizeIngredients(imageBase64: string): Promise<string[
       const tried = body?.tried as string[] | undefined;
       throw new Error(tried?.length ? `${msg}\n시도된 모델: ${tried.join(", ")}` : msg);
     } catch (e) {
-      if (e instanceof Error) throw e;
+      if (e instanceof Error && !(e instanceof SyntaxError)) throw e;
       throw new Error(`서버 오류 (${res.status})`);
     }
   }


### PR DESCRIPTION
## Summary

Multi-agent code review pipeline (code-quality-reviewer → perf-optimizer → ux-design-reviewer) 결과를 반영한 버그 수정 및 UX 개선 PR입니다.

### 🔴 Bug Fixes (`fix(fridge-recipe)`)

- **IME isComposing 누락** (`IngredientTagList.tsx`): 한글 조합 중 Enter 시 미완성 글자가 태그로 추가되던 버그 수정
- **Object URL 메모리 누수** (`page.tsx`): 이미지 교체 시 이전 `createObjectURL` 결과를 `revokeObjectURL`로 정리
- **SyntaxError 사용자 노출** (`openrouter.ts`): 에러 응답 JSON 파싱 실패 시 `SyntaxError`가 그대로 throw되던 문제 — 일반 서버 오류 메시지로 대체
- **Canvas non-null assertion** (`compressImage.ts`): `getContext("2d")!` → null 체크 후 명시적 reject

### ✨ UX Improvements (`feat(fridge-recipe)`)

| 영역 | 내용 |
|------|------|
| 에러 복구 | 에러 배너에 "다시 시도" 버튼 + `role="alert"` |
| 빈 상태 | AI 재료 인식 0개 시 즉시 수동 입력 유도, 즐겨찾기 필터 빈 상태 CTA |
| 흐름 연속성 | Step 2에서 프로필 알레르기/특이사항 반영 힌트 표시 |
| 로딩 | 스트리밍 중 "AI가 레시피를 작성 중" 안내 텍스트 |
| 삭제 확인 | Saved 페이지 삭제 시 확인 다이얼로그 (`role=dialog`, `aria-modal`) |
| 접근성 | `ImageDropzone` 키보드 지원, `aria-*` 속성 전반, `RecipeCard` 저장 버튼 동적 레이블 |
| 내비게이션 | `/step2` 경로에서 냉장고 탭 active 상태 수정 |

### Runtime fixes also in UX commit

- `step2/page.tsx`: `setTimeout` cleanup, `useCallback` deps에 `sessionKey` 추가, `RecipeCard` key 안정화 (`name + index` → `name`)
- `saved/page.tsx`: JSX 내 IIFE → `filteredRecipes` 변수 추출

## Test plan

- [x] 한글 입력 후 Enter → 조합 완료 전 태그 추가 안 됨
- [x] 이미지 여러 번 교체 → 메모리 증가 없음 (DevTools Memory 확인)
- [x] Step 2에서 에러 발생 → "다시 시도" 버튼 클릭 시 재요청
- [x] AI 재료 인식 결과 0개 → 빈 상태 + 수동 입력 영역 노출
- [x] Saved 페이지 삭제 버튼 → 확인 다이얼로그 표시
- [x] `/step2` 진입 시 냉장고 탭 active 상태 확인
- [x] Tab 키로 `ImageDropzone` 포커스 → Enter/Space로 파일 선택 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)