### PR TITLE
chore(agent): worktree 점검 프로세스 추가

### DIFF
--- a/.agent/AGENT.md
+++ b/.agent/AGENT.md
@@ -24,7 +24,8 @@
 | 3 | [rules/coding-style.md](rules/coding-style.md) | 코딩 스타일, 파일/함수 크기, 구조 규칙 |
 | 4 | [rules/conflict-resolution.md](rules/conflict-resolution.md) | 충돌 발생 시 설명, 계획, 검증 절차 |
 | 5 | [rules/agent-scope.md](rules/agent-scope.md) | 에이전트별 파일 소유권과 작업 범위 |
-| 6 | [rules/agent-creation.md](rules/agent-creation.md) | 새 에이전트 생성 규칙 |
+| 6 | [rules/worktree-hygiene.md](rules/worktree-hygiene.md) | 작업 전환 전후 worktree 점검과 정리 절차 |
+| 7 | [rules/agent-creation.md](rules/agent-creation.md) | 새 에이전트 생성 규칙 |
 
 규칙 충돌 시 `security` > `performance` > `coding-style` > `skills` 순서로 적용합니다.
 
@@ -88,6 +89,7 @@ Vite 등의 빌드 환경 도입은 Sprint 5 기준으로 보류 상태이며, T
 |---------|------|
 | [commands/code-review.md](commands/code-review.md) | 커밋 전 코드 품질 및 보안 검토 |
 | [commands/refactor-clean.md](commands/refactor-clean.md) | 미사용 코드 탐지 및 안전 제거 |
+| [commands/worktree-check.md](commands/worktree-check.md) | 작업 시작/종료 전 worktree 상태 점검 |
 | [commands/notion-daily.md](commands/notion-daily.md) | 오늘자 노션 기록 페이지 생성/업데이트 |
 | [commands/dev-team/orchestrate.md](commands/dev-team/orchestrate.md) | 요청 분석 후 적합한 서브에이전트 라우팅 |
 | [commands/dev-team/oc.md](commands/dev-team/oc.md) | `/orchestrate` 축약 별칭 |

--- a/.agent/commands/worktree-check.md
+++ b/.agent/commands/worktree-check.md
@@ -1,0 +1,74 @@
+---
+description: 작업 시작/종료 전 git worktree 상태를 점검하고 정리 후보를 분류한다. 삭제는 사용자 승인 없이는 하지 않는다.
+---
+
+# Worktree Check
+
+작업 전환 시 Source Control에 남은 격리 worktree가 혼선을 만들지 않도록 점검한다.
+
+## Step 1 — 전체 worktree 목록 확인
+
+```bash
+git worktree list
+```
+
+각 항목에서 아래 정보를 수집한다.
+
+- 경로
+- HEAD 커밋
+- 브랜치명
+
+## Step 2 — 각 worktree dirty 상태 확인
+
+현재 작업과 관련 있어 보이는 worktree부터 확인한다.
+
+```bash
+git -C <worktree-path> status --short --branch
+```
+
+`.claude/worktrees/`, `/private/tmp/`, `/tmp/` 아래 worktree는 임시 작업 후보로 표시한다.
+
+## Step 3 — PR 상태 확인
+
+브랜치가 원격에 있거나 PR용으로 보이면 확인한다.
+
+```bash
+gh pr list --head <branch> --json number,title,state,url
+```
+
+GitHub CLI 또는 네트워크가 불가하면 "PR 상태 미확인"으로 표시하고 삭제 후보에서 제외한다.
+
+## Step 4 — 분류
+
+| 상태 | 기준 | 처리 |
+|------|------|------|
+| Active | 현재 요청을 수행 중이거나 아직 PR/커밋이 필요한 worktree | 유지 |
+| Pending Review | PR이 열려 있고 리뷰/머지를 기다리는 worktree | 유지, PR URL 보고 |
+| Candidate Cleanup | PR이 머지됐거나 작업이 중단됐고 변경이 없는 worktree | 사용자 승인 후 제거 |
+| Dirty Unknown | 변경 파일이 있고 현재 요청과 관련이 불명확한 worktree | 제거 금지, 사용자에게 보고 |
+
+## Step 5 — 보고
+
+아래 형식으로 출력한다.
+
+```text
+Worktree 점검 결과
+- Active: [N]개
+- Pending Review: [N]개
+- Candidate Cleanup: [N]개
+- Dirty Unknown: [N]개
+
+정리 후보:
+- [경로] ([브랜치]) — 이유: [PR merged / clean stale / 중단 작업 등]
+
+주의:
+- dirty worktree는 삭제하지 않았습니다.
+- 삭제가 필요하면 승인 후 `git worktree remove <path>`를 실행합니다.
+```
+
+## Rules
+
+- 사용자 승인 없이 `git worktree remove`를 실행하지 않는다.
+- dirty worktree를 삭제하지 않는다.
+- 메인 worktree의 사용자 변경은 정리하지 않는다.
+- 삭제 전에는 경로, 브랜치, HEAD, dirty 여부를 다시 확인한다.

--- a/.agent/rules/worktree-hygiene.md
+++ b/.agent/rules/worktree-hygiene.md
@@ -1,0 +1,57 @@
+# Worktree Hygiene Rules
+
+수산시장 팀은 작업 전환 시 남은 worktree가 Source Control에 노출되어 혼선을 만들지 않도록,
+각 작업의 시작 전과 종료 후에 worktree 상태를 확인한다.
+
+## Required Checkpoints
+
+아래 시점마다 반드시 worktree를 점검한다.
+
+1. 새 작업을 시작하기 전
+2. PR 생성 또는 작업 완료 직후
+3. 다른 브랜치나 다른 격리 worktree로 전환하기 전
+4. Source Control에 예상하지 못한 변경 묶음이 보일 때
+
+## Check Commands
+
+```bash
+git worktree list
+git status --short --branch
+```
+
+worktree 경로가 `.claude/worktrees/`, `/private/tmp/`, `/tmp/` 아래에 있으면 임시 작업일 가능성이 높다.
+하지만 임시 경로라는 이유만으로 삭제하지 않는다.
+
+## Classification
+
+점검한 worktree는 아래 중 하나로 분류한다.
+
+| 상태 | 기준 | 처리 |
+|------|------|------|
+| Active | 현재 요청을 수행 중이거나 아직 PR/커밋이 필요한 worktree | 유지 |
+| Pending Review | PR이 열려 있고 리뷰/머지를 기다리는 worktree | 유지, PR URL과 함께 보고 |
+| Candidate Cleanup | PR이 머지됐거나 작업이 중단됐고 변경이 없는 worktree | 사용자 확인 후 제거 |
+| Dirty Unknown | 변경 파일이 있고 현재 요청과 관련이 불명확한 worktree | 제거 금지, 사용자에게 보고 |
+
+## Cleanup Rules
+
+- `git worktree remove`는 사용자가 명시적으로 승인했을 때만 실행한다.
+- dirty worktree는 제거하지 않는다. 먼저 해당 worktree에서 `git status --short --branch`를 확인한다.
+- 제거 전에는 worktree 경로, 브랜치명, HEAD 커밋, dirty 여부를 사용자에게 요약한다.
+- PR이 열린 branch는 PR 상태를 확인하기 전까지 제거하지 않는다.
+- 메인 worktree의 기존 사용자 변경은 절대 정리 대상으로 삼지 않는다.
+
+## Handoff Report
+
+작업 완료 보고에는 필요한 경우 아래를 포함한다.
+
+```text
+Worktree 상태:
+- 현재 작업: [경로] ([브랜치]) — clean/dirty
+- 열린 PR: [URL 또는 없음]
+- 정리 후보: [경로/브랜치] — 사용자 승인 필요
+```
+
+## Command
+
+반복 점검은 `.agent/commands/worktree-check.md` 절차를 따른다.

--- a/.claude/commands/worktree-check.md
+++ b/.claude/commands/worktree-check.md
@@ -1,0 +1,7 @@
+---
+description: 작업 시작/종료 전 git worktree 상태를 점검하고 정리 후보를 분류한다. 삭제는 사용자 승인 없이는 하지 않는다.
+---
+
+> Thin wrapper - 실제 정의는 `.agent/commands/worktree-check.md`를 읽으세요.
+
+Read [`.agent/commands/worktree-check.md`](../../.agent/commands/worktree-check.md) and follow it.

--- a/.cursor/commands/worktree-check.md
+++ b/.cursor/commands/worktree-check.md
@@ -1,0 +1,7 @@
+---
+description: 작업 시작/종료 전 git worktree 상태를 점검하고 정리 후보를 분류한다. 삭제는 사용자 승인 없이는 하지 않는다.
+---
+
+> Thin wrapper - 실제 정의는 `.agent/commands/worktree-check.md`를 읽으세요.
+
+Read [`.agent/commands/worktree-check.md`](../../.agent/commands/worktree-check.md) and follow it.


### PR DESCRIPTION
## 요약

- 수산시장 필수 rules에 worktree hygiene 절차를 추가했습니다.
- 작업 시작/종료 및 브랜치 전환 전 `git worktree list` 기반 점검을 명문화했습니다.
- 반복 실행용 `/worktree-check` command와 Claude/Cursor wrapper를 추가했습니다.

## 확인

- `git diff --cached --name-only`로 worktree 관련 5개 파일만 커밋 대상임을 확인했습니다.
- `git log --oneline sprint/mini-judge/1..HEAD` 결과 이번 커밋 1개만 포함됩니다.
- mini-judge 작업 파일과 `.claude/worktrees/` 변경은 커밋하지 않았습니다.

## 참고

- Base branch: `sprint/mini-judge/1`
- Head branch: `chore/worktree-hygiene-process`
- Commit: `d3ea607 chore(agent): worktree 점검 프로세스 추가`
